### PR TITLE
Fixed: email schema

### DIFF
--- a/backend/validators/adminValidator.js
+++ b/backend/validators/adminValidator.js
@@ -7,7 +7,7 @@ const emailSchema = Joi.string().email({ tlds: { allow: false } }); // Basic ema
 // Joi schema for validating admin login credentials
 const adminLoginSchema = Joi.object({
     // This field can now be either a username or an email
-    emailOrUsername: Joi.alternatives()
+    email: Joi.alternatives()
         .try(usernameSchema, emailSchema)
         .required()
         .messages({


### PR DESCRIPTION
This pull request makes a minor change to the admin login validation schema by renaming the field that accepts either a username or an email. The field name is changed from `emailOrUsername` to `email` in `backend/validators/adminValidator.js`.